### PR TITLE
Feat:Improve the usage of the Recognizer in the Demo to reduce memory…

### DIFF
--- a/app/src/main/java/org/vosk/demo/VoskActivity.java
+++ b/app/src/main/java/org/vosk/demo/VoskActivity.java
@@ -55,6 +55,7 @@ public class VoskActivity extends Activity implements
     private SpeechService speechService;
     private SpeechStreamService speechStreamService;
     private TextView resultView;
+    private Recognizer rec;
 
     @Override
     public void onCreate(Bundle state) {
@@ -114,6 +115,8 @@ public class VoskActivity extends Activity implements
             speechService.stop();
             speechService.shutdown();
         }
+
+        closeRec();
 
         if (speechStreamService != null) {
             speechStreamService.stop();
@@ -204,10 +207,11 @@ public class VoskActivity extends Activity implements
             setUiState(STATE_DONE);
             speechStreamService.stop();
             speechStreamService = null;
+            closeRec();
         } else {
             setUiState(STATE_FILE);
             try {
-                Recognizer rec = new Recognizer(model, 16000.f, "[\"one zero zero zero one\", " +
+                rec = new Recognizer(model, 16000.f, "[\"one zero zero zero one\", " +
                         "\"oh zero one two three four five six seven eight nine\", \"[unk]\"]");
 
                 InputStream ais = getAssets().open(
@@ -227,10 +231,11 @@ public class VoskActivity extends Activity implements
             setUiState(STATE_DONE);
             speechService.stop();
             speechService = null;
+            closeRec();
         } else {
             setUiState(STATE_MIC);
             try {
-                Recognizer rec = new Recognizer(model, 16000.0f);
+                rec = new Recognizer(model, 16000.0f);
                 speechService = new SpeechService(rec, 16000.0f);
                 speechService.startListening(this);
             } catch (IOException e) {
@@ -239,6 +244,15 @@ public class VoskActivity extends Activity implements
         }
     }
 
+    /**
+     * Release the resources of the Recognizer object
+     */
+    private void closeRec(){
+        if (rec!=null) {
+            rec.close();
+            rec = null;
+        }
+    }
 
     private void pause(boolean checked) {
         if (speechService != null) {


### PR DESCRIPTION
我看到作者会中文加之我的英文较差怕引起歧义使用中提出此PR。

这一个非常棒的项目，帮我解决了一些项目中的问题。

(1) 我发现Demo在持续运行时内存不断增加。点击停止后按钮内存依旧没有回收。
在翻阅Issues发现类似问题[类似Issues](https://github.com/alphacep/vosk-android-demo/issues/121)

我发现问题有两个：
**问题1.** Recognizer在Native指针始终没有释放所以点击停止录音并没有释放对应内存
**问题2.** 持续录制时会不断存储缓存并从不释放，比较核心的代码如下。**Expand**内部代码内部调用**PushArc**将内存占用情况劣化。openfst我看到有内存gc机制由于我对于音视频知识匮乏暂无往下继续研究。这个情况我在IOS也发现存在。

```cpp
//openfst arc-map.h 
size_t NumArcs(StateId s) {
    if (!HasArcs(s)) Expand(s);
    return CacheImpl<B>::NumArcs(s);
  }
size_t NumInputEpsilons(StateId s) {
    if (!HasArcs(s)) Expand(s);
    return CacheImpl<B>::NumInputEpsilons(s);
  }
```
此PR主要解决**问题1**
